### PR TITLE
TopographicalFactorAnalysis: enable saving mean parameters to Matlab …

### DIFF
--- a/htfa_torch/tfa.py
+++ b/htfa_torch/tfa.py
@@ -363,7 +363,7 @@ class TopographicalFactorAnalysis:
         }
         return result
 
-    def mean_parameters(self, log_level=logging.WARNING):
+    def mean_parameters(self, log_level=logging.WARNING, matfile=None):
         logging.basicConfig(format='%(asctime)s %(message)s',
                             datefmt='%m/%d/%Y %H:%M:%S',
                             level=log_level)
@@ -395,6 +395,10 @@ class TopographicalFactorAnalysis:
             'mean_factor_center': mean_factor_center,
             'mean_factor_log_width': mean_factor_log_width
         }
+
+        if matfile is not None:
+            sio.savemat(matfile, mean_parameters, do_compression=True)
+
         return mean_parameters
 
     def save(self, out_dir='.'):


### PR DESCRIPTION
…file

Sometimes we might we want to save our inferred mean parameters to a Matlab
matrix file, so as to examine them in other environments.

Testing Done: reloaded mat file with sio.loadmat via console

Signed-off-by: Eli Sennesh <e.sennesh@northeastern.edu>